### PR TITLE
Abstractify the boot selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+BOOT_SEL := 5	#See u-boot/doc/board/amlogic/boot-flow.rst
 MCU := atmega328p
 PROGPORT := /dev/ttyUSB0
 
 CC := avr-gcc
-CFLAGS := -mmcu=$(MCU) -Wall -Wextra -O2 -std=gnu11
+CFLAGS := -mmcu=$(MCU) -Wall -Wextra -O2 -std=gnu11 -DBOOT_SEL=$(BOOT_SEL)
 LDFLAGS := -mmcu=$(MCU)
 
 i2c-flash: i2c-flash.o

--- a/i2c-flash.c
+++ b/i2c-flash.c
@@ -3,10 +3,18 @@
 #include <avr/sleep.h>
 #include <util/twi.h>
 
+#define _BOOT_1 SPI
+#define _BOOT_4 SDC
+#define _BOOT_5 USB
+
+#define _BOOT_(s) "boot@" #s
+#define _BOOT(s) _BOOT_(s)
+#define _SEL_(s) _BOOT_ ## s
+#define _SEL(s) _SEL_(s)
+
 const uint8_t emulated_addr = 0x52;
 
-const uint8_t emulated_data[] = "boot@USB";
-//const uint8_t emulated_data[] = "boot@SDC";
+const uint8_t emulated_data[] = _BOOT(_SEL(BOOT_SEL));
 const uint8_t emulated_data_start = 0xf8;
 
 ISR(TWI_vect) {


### PR DESCRIPTION
This moves the commenting/uncommenting of USB/SDC to the make command line.