### PR TITLE
Add a couple of sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ appropriately in the Makefile.
 
 To use, attach the SCL and SDA DDC lines (pins 15 and 16, respectively) of an
 HDMI breakout to the I2C lines on your AVR (which are PC5 and PC4, respectively,
-on the ATmega48/88/168/328), connect the HDMI port to your target device, then
-apply power to the device. It should enter BootROM USB DFU mode with no
-additional interaction needed.
+on the ATmega48/88/168/328), attach HDMI pin 17 to GND, and shunt HDMI pins 18
+and 19 together, then connect that to your target device and apply power to it.
+The SoC should enter BootROM USB DFU mode with no additional interaction needed.
 
 [1]: https://www.exploitee.rs/index.php/FireFU_Exploit
 [2]: https://github.com/superna9999/linux/wiki/Amlogic-HDMI-Boot-Dongle


### PR DESCRIPTION
After the Arduino responds over I2C, its TWI interface was being left in some kind of undefined state, so if the target device were to lose power momentarily while the Arduino is still powered, it wouldn't respond a second time, and the target device would attempt a full boot. I borrowed a bit of code from Wire.cpp in the Arduino IDE that seems to clean this up such that the Arduino can respond again and again most of the time if need be.